### PR TITLE
Implement new Hyperliquid endpoints

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,14 @@
 import { PublicClient } from "@nktkas/hyperliquid";
 
-import { candleSnapshotSchema, l2BookSchema } from "./schemas.js";
+import {
+  candleSnapshotSchema,
+  l2BookSchema,
+  openOrdersSchema,
+  userFillsSchema,
+  userFillsByTimeSchema,
+  orderStatusSchema,
+  clearinghouseStateSchema,
+} from "./schemas.js";
 
 export async function getL2Book(
   hyperliquidClient: PublicClient,
@@ -8,7 +16,7 @@ export async function getL2Book(
 ) {
   const validatedArgs = l2BookSchema.parse(args);
 
-  let l2Book = await hyperliquidClient.l2Book(validatedArgs);
+  const l2Book = await hyperliquidClient.l2Book(validatedArgs);
   return {
     content: [{ type: "text", text: JSON.stringify(l2Book) }],
     isError: false,
@@ -16,7 +24,7 @@ export async function getL2Book(
 }
 
 export async function getAllMids(hyperliquidClient: PublicClient) {
-  let allMids = await hyperliquidClient.allMids();
+  const allMids = await hyperliquidClient.allMids();
   return {
     content: [{ type: "text", text: JSON.stringify(allMids) }],
     isError: false,
@@ -31,6 +39,66 @@ export async function getCandleSnapshot(
   const candleSnapshot = await hyperliquidClient.candleSnapshot(validatedArgs);
   return {
     content: [{ type: "text", text: JSON.stringify(candleSnapshot) }],
+    isError: false,
+  };
+}
+
+export async function getOpenOrders(
+  hyperliquidClient: PublicClient,
+  args: unknown
+) {
+  const validatedArgs = openOrdersSchema.parse(args);
+  const openOrders = await hyperliquidClient.openOrders(validatedArgs);
+  return {
+    content: [{ type: "text", text: JSON.stringify(openOrders) }],
+    isError: false,
+  };
+}
+
+export async function getUserFills(
+  hyperliquidClient: PublicClient,
+  args: unknown
+) {
+  const validatedArgs = userFillsSchema.parse(args);
+  const fills = await hyperliquidClient.userFills(validatedArgs);
+  return {
+    content: [{ type: "text", text: JSON.stringify(fills) }],
+    isError: false,
+  };
+}
+
+export async function getUserFillsByTime(
+  hyperliquidClient: PublicClient,
+  args: unknown
+) {
+  const validatedArgs = userFillsByTimeSchema.parse(args);
+  const fills = await hyperliquidClient.userFillsByTime(validatedArgs);
+  return {
+    content: [{ type: "text", text: JSON.stringify(fills) }],
+    isError: false,
+  };
+}
+
+export async function getOrderStatus(
+  hyperliquidClient: PublicClient,
+  args: unknown
+) {
+  const validatedArgs = orderStatusSchema.parse(args);
+  const status = await hyperliquidClient.orderStatus(validatedArgs);
+  return {
+    content: [{ type: "text", text: JSON.stringify(status) }],
+    isError: false,
+  };
+}
+
+export async function getClearinghouseState(
+  hyperliquidClient: PublicClient,
+  args: unknown
+) {
+  const validatedArgs = clearinghouseStateSchema.parse(args);
+  const state = await hyperliquidClient.clearinghouseState(validatedArgs);
+  return {
+    content: [{ type: "text", text: JSON.stringify(state) }],
     isError: false,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,26 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import * as hl from "@nktkas/hyperliquid";
 
-import { ALL_MIDS_TOOL, CANDLE_SNAPSHOT_TOOL, L2_BOOK_TOOL } from "./tools.js";
-import { getAllMids, getCandleSnapshot, getL2Book } from "./actions.js";
+import {
+  ALL_MIDS_TOOL,
+  CANDLE_SNAPSHOT_TOOL,
+  L2_BOOK_TOOL,
+  OPEN_ORDERS_TOOL,
+  USER_FILLS_TOOL,
+  USER_FILLS_BY_TIME_TOOL,
+  ORDER_STATUS_TOOL,
+  CLEARINGHOUSE_STATE_TOOL,
+} from "./tools.js";
+import {
+  getAllMids,
+  getCandleSnapshot,
+  getL2Book,
+  getOpenOrders,
+  getUserFills,
+  getUserFillsByTime,
+  getOrderStatus,
+  getClearinghouseState,
+} from "./actions.js";
 
 async function main() {
   console.error("Starting Hyperliquid MCP server...");
@@ -24,9 +42,7 @@ async function main() {
 
   console.error("Starting Hyperliquid client");
   const hyperliquidTransport = new hl.HttpTransport();
-  const hyperliquidClient = new hl.PublicClient({
-    transport: hyperliquidTransport,
-  });
+  const hyperliquidClient = new hl.PublicClient({ transport: hyperliquidTransport });
 
   server.setRequestHandler(
     CallToolRequestSchema,
@@ -34,11 +50,9 @@ async function main() {
       console.error("Received CallToolRequest:", request);
       try {
         const { name, arguments: args } = request.params;
-
         if (!args) {
           throw new Error("No arguments provided");
         }
-
         switch (name) {
           case "get_l2_book": {
             return await getL2Book(hyperliquidClient, args);
@@ -49,7 +63,21 @@ async function main() {
           case "get_candle_snapshot": {
             return await getCandleSnapshot(hyperliquidClient, args);
           }
-
+          case "get_open_orders": {
+            return await getOpenOrders(hyperliquidClient, args);
+          }
+          case "get_user_fills": {
+            return await getUserFills(hyperliquidClient, args);
+          }
+          case "get_user_fills_by_time": {
+            return await getUserFillsByTime(hyperliquidClient, args);
+          }
+          case "get_order_status": {
+            return await getOrderStatus(hyperliquidClient, args);
+          }
+          case "get_clearinghouse_state": {
+            return await getClearinghouseState(hyperliquidClient, args);
+          }
           default:
             return {
               content: [{ type: "text", text: `Unknown tool: ${name}` }],
@@ -61,9 +89,7 @@ async function main() {
           content: [
             {
               type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
+              text: `Error: ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
           isError: true,
@@ -75,7 +101,16 @@ async function main() {
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     console.error("Received ListToolsRequest");
     return {
-      tools: [ALL_MIDS_TOOL, CANDLE_SNAPSHOT_TOOL, L2_BOOK_TOOL],
+      tools: [
+        ALL_MIDS_TOOL,
+        CANDLE_SNAPSHOT_TOOL,
+        L2_BOOK_TOOL,
+        OPEN_ORDERS_TOOL,
+        USER_FILLS_TOOL,
+        USER_FILLS_BY_TIME_TOOL,
+        ORDER_STATUS_TOOL,
+        CLEARINGHOUSE_STATE_TOOL,
+      ],
     };
   });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -29,3 +29,46 @@ export const l2BookSchema = z
     nSigFigs: data.nSigFigs,
     mantissa: data.mantissa,
   }));
+
+const hexAddress = z
+  .string()
+  .regex(/^0x[0-9A-Fa-f]{40}$/, {
+    message: "User must be a 42-character hex address (0x followed by 40 hex digits)",
+  });
+
+export const openOrdersSchema = z
+  .object({
+    user: hexAddress,
+  })
+  .strict();
+
+export const userFillsSchema = z
+  .object({
+    user: hexAddress,
+    aggregateByTime: z.boolean().optional().default(false),
+  })
+  .strict();
+
+export const userFillsByTimeSchema = z
+  .object({
+    user: hexAddress,
+    startTime: z.number({
+      required_error: "Start time must be a number (ms since epoch)",
+    }),
+    endTime: z.number().optional(),
+    aggregateByTime: z.boolean().optional().default(false),
+  })
+  .strict();
+
+export const orderStatusSchema = z
+  .object({
+    user: hexAddress,
+    oid: z.union([z.string(), z.number()]),
+  })
+  .strict();
+
+export const clearinghouseStateSchema = z
+  .object({
+    user: hexAddress,
+  })
+  .strict();

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -16,7 +16,7 @@ export const CANDLE_SNAPSHOT_TOOL: Tool = {
   inputSchema: {
     type: "object",
     properties: {
-      coin: {
+      symbol: {
         type: "string",
         description: "The symbol of the token to get candlestick data for",
       },
@@ -33,21 +33,131 @@ export const CANDLE_SNAPSHOT_TOOL: Tool = {
         description: "End time in milliseconds since epoch (optional)",
       },
     },
-    required: ["coin", "interval", "startTime"],
+    required: ["symbol", "interval", "startTime"],
   },
 };
 
 export const L2_BOOK_TOOL: Tool = {
   name: "get_l2_book",
-  description: "Get the L2 book of a token on Hyperliquid",
+  description: "Get the L2 order book (depth) of a token on Hyperliquid",
   inputSchema: {
     type: "object",
     properties: {
       symbol: {
         type: "string",
-        description: "The symbol of the token to get the price of",
+        description: "The symbol of the token to get the order book for",
       },
-      required: ["symbol"],
+      nSigFigs: {
+        type: "number",
+        description:
+          "Optional: aggregate price levels to this number of significant figures (2-5)",
+      },
+      mantissa: {
+        type: "number",
+        description:
+          "Optional: mantissa (2 or 5) for price levels if nSigFigs = 5",
+      },
     },
+    required: ["symbol"],
+  },
+};
+
+export const OPEN_ORDERS_TOOL: Tool = {
+  name: "get_open_orders",
+  description: "Get all open orders for a given user on Hyperliquid",
+  inputSchema: {
+    type: "object",
+    properties: {
+      user: {
+        type: "string",
+        description: "The user's address (0x... hex) whose open orders to retrieve",
+      },
+    },
+    required: ["user"],
+  },
+};
+
+export const USER_FILLS_TOOL: Tool = {
+  name: "get_user_fills",
+  description: "Get recent trade fills (executed orders) for a given user on Hyperliquid",
+  inputSchema: {
+    type: "object",
+    properties: {
+      user: {
+        type: "string",
+        description: "The user's address (0x... hex) to fetch fills for",
+      },
+      aggregateByTime: {
+        type: "boolean",
+        description:
+          "Optional: true to aggregate partial fills that occurred at the same time",
+      },
+    },
+    required: ["user"],
+  },
+};
+
+export const USER_FILLS_BY_TIME_TOOL: Tool = {
+  name: "get_user_fills_by_time",
+  description: "Get trade fills for a user within a time range on Hyperliquid",
+  inputSchema: {
+    type: "object",
+    properties: {
+      user: {
+        type: "string",
+        description: "The user's address (0x... hex) to fetch fills for",
+      },
+      startTime: {
+        type: "number",
+        description: "Start time (ms since epoch) for the query range (inclusive)",
+      },
+      endTime: {
+        type: "number",
+        description:
+          "End time (ms since epoch) for the query range (optional, defaults to now)",
+      },
+      aggregateByTime: {
+        type: "boolean",
+        description:
+          "Optional: true to aggregate partial fills that occurred at the same time",
+      },
+    },
+    required: ["user", "startTime"],
+  },
+};
+
+export const ORDER_STATUS_TOOL: Tool = {
+  name: "get_order_status",
+  description: "Check the status of an order by its ID on Hyperliquid",
+  inputSchema: {
+    type: "object",
+    properties: {
+      user: {
+        type: "string",
+        description: "The user's address (0x... hex) who placed the order",
+      },
+      oid: {
+        type: ["string", "number"],
+        description:
+          "The order ID (as a number) or client order ID (as a 16-byte hex string)",
+      },
+    },
+    required: ["user", "oid"],
+  },
+};
+
+export const CLEARINGHOUSE_STATE_TOOL: Tool = {
+  name: "get_clearinghouse_state",
+  description:
+    "Get the perpetual account state (margin and positions) for a given user on Hyperliquid",
+  inputSchema: {
+    type: "object",
+    properties: {
+      user: {
+        type: "string",
+        description: "The user's address (0x... hex) whose account state to retrieve",
+      },
+    },
+    required: ["user"],
   },
 };


### PR DESCRIPTION
## Summary
- define open order/fill/order status/clearinghouse tools
- validate user input via new schemas
- add action functions calling Hyperliquid client
- register the tools and handlers in the main server

## Testing
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685c2b763a70832e87f06f4670edc8bd